### PR TITLE
Allow multiple device input files

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -52,7 +52,7 @@ int Config::mLcdPort;
 string Config::mPlayerId;
 bool Config::mFixedVolume;
 int Config::mVolume;
-string Config::mInputDeviceFile;
+vector<string> Config::mInputDeviceFiles;
 string Config::mEncoding;
 int Config::mScrollSpeed;
 
@@ -72,7 +72,7 @@ int Config::processOptions(int argc, char* argv[])
 	ValueArg<string> macArg("m", "mac", "the player's MAC address (default: automatic, first interface)", false, "", "AA:BB:CC:DD:EE:FF");
 	SwitchArg fixedvolumeArg("f", "fixedvolume", "volume control disabled", false);
 	ValueArg<int> volumeArg("o", "volume", "set volume on startup", false, -1, "0-100");
-	ValueArg<string> inputArg("i", "input", "keyboard input device file (default: /dev/input/event0)", false, "/dev/input/event0", "input device file");
+	ValueArg<string> inputArg("i", "input", "keyboard input device file(s). Use comma to delimit multiple input files. (default: /dev/input/event0)", false, "/dev/input/event0", "input device file");
 	ValueArg<string> encodingArg("e", "encoding", "the LCD's character encoding (default: ISO-8859-1)", false, "ISO-8859-1", "single-byte encoding");
 	ValueArg<int> scrollspeedArg("c", "scrollspeed", "text scrolling speed (default: 3)", false, 3, "0-10");
 
@@ -91,14 +91,33 @@ int Config::processOptions(int argc, char* argv[])
 	cmd.parse(argc, argv);
 
 	mVerbose = verboseArg.getValue();
+	std::cout << "mLmsHost (before) \"" << mLmsHost << "\"" << std::endl;
+	std::cout << "is empty (before) " << mLmsHost.empty() << std::endl;
 	mLmsHost = lmshostArg.getValue();
+	std::cout << "mLmsHost " << mLmsHost << std::endl;
+	std::cout << "is empty " << mLmsHost.empty() << std::endl;
+	std::cout << "mLmsHost " << mLmsHost << std::endl;
 	mLmsPort = lmsportArg.getValue();
+	std::cout << "mLmsPort " << mLmsPort << std::endl;
 	mLcdHost = lcdhostArg.getValue();
 	mLcdPort = lcdportArg.getValue();
 	mPlayerId = macArg.getValue();
 	mFixedVolume = fixedvolumeArg.getValue();
 	mVolume = volumeArg.getValue();
-	mInputDeviceFile = inputArg.getValue();
+
+	// Save string to stream. Pull off chunks, broken up by ','
+	std::stringstream unparsed_data(inputArg.getValue());
+	while(unparsed_data.good()) {
+		std::string substr;
+		std::getline(unparsed_data, substr, ',');
+		mInputDeviceFiles.push_back(substr);
+	}
+	if (Config::verbose())
+	{
+		for (string const i_file : mInputDeviceFiles)
+			cout << "found device input file: " << i_file << endl;
+	}
+
 	mEncoding = encodingArg.getValue();
 	mScrollSpeed = scrollspeedArg.getValue();
 

--- a/Config.h
+++ b/Config.h
@@ -20,6 +20,7 @@
 #define CONFIG_H
 
 #include <string>
+#include <vector>
 
 using namespace std;
 
@@ -37,7 +38,7 @@ public:
 	const string static playerId() { return mPlayerId; }
 	const bool static fixedVolume() { return mFixedVolume; }
 	const int static volume() { return mVolume; }
-	const string static inputDeviceFile() { return mInputDeviceFile; }
+	const vector<string> static inputDeviceFiles() { return mInputDeviceFiles; }
 	const string static encoding() { return mEncoding; }
 	const int static scrollSpeed() { return mScrollSpeed; }
 
@@ -68,7 +69,7 @@ protected:
 	string static mPlayerId;
 	bool static mFixedVolume;
 	int static mVolume;
-	string static mInputDeviceFile;
+	vector<string> static mInputDeviceFiles;
 	string static mEncoding;
 	int static mScrollSpeed;
 };

--- a/Controller.cpp
+++ b/Controller.cpp
@@ -382,6 +382,29 @@ void Controller::readInput(ev::io& w, int revents)
 			Button::ButtonEvent buttonEvent = inputEvent.value == 1 ? Button::PRESS : inputEvent.value == 0 ? Button::RELEASE : Button::REPEAT;
 			for (Button* const button : mButtons)
 				button->handleKey(buttonEvent, inputEvent.code);
+		} else if (readSize == sizeof(inputEvent) && inputEvent.type == EV_REL && (inputEvent.value == 1 || inputEvent.value == -1))
+		{
+			if (Config::verbose())
+				cout << "Matched EV_SYN event. inputEvent.value=" << inputEvent.value << " inputEvent.code=" << inputEvent.code << endl;
+			if (inputEvent.value == 1)
+			{
+				if (Config::verbose())
+					cout << "Matched inputEvent.value == 1" << endl;
+				for (Button* const button : mButtons)
+				{
+					button->handleKey((Button::ButtonEvent) Button::PRESS, KEY_LEFT);
+					button->handleKey((Button::ButtonEvent) Button::RELEASE, KEY_LEFT);
+				}
+			} else if (inputEvent.value == -1)
+			{
+				if (Config::verbose())
+					cout << "Matched inputEvent.value == -1" << endl;
+				for (Button* const button : mButtons)
+				{
+					button->handleKey((Button::ButtonEvent) Button::PRESS, KEY_RIGHT);
+					button->handleKey((Button::ButtonEvent) Button::RELEASE, KEY_RIGHT);
+				}
+			}
 		}
 	}
 	if (readSize == -1 && errno != EAGAIN && errno != EINTR)

--- a/Controller.h
+++ b/Controller.h
@@ -80,13 +80,14 @@ protected:
 	ScreenMenu mMenuScreen;
 	ScreenVolume mVolumeScreen;
 
-	ev::io mInputDeviceIo;
+	vector<ev::io*> mInputDevicesIo;
+
 	ev::timer mStatusUpdateTimer;
 	ev::timer mVolumeScreenHideTimer;
 	ev::timer mMenuScreenHideTimer;
 	ev::timer mPopupHideTimer;
 	ev::timer mStandbyTimer;
-	int mInputDeviceFileDescriptor;
+	vector<int> mInputDeviceFileDescriptors;
 
 	vector<Button*> mButtons;
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Where:
      set volume on startup
 
    -i <input device file>,  --input <input device file>
-     keyboard input device file (default: /dev/input/event0)
+     keyboard input device file(s). Use comma to delimit multiple input files. (default: /dev/input/event0)
 
    -e <single-byte encoding>,  --encoding <single-byte encoding>
      the LCD's character encoding (default: ISO-8859-1)

--- a/main.cpp
+++ b/main.cpp
@@ -45,7 +45,9 @@ int main(int argc, char* argv[])
 		cout << "  LMS: " << Config::lmsHost() << ":" << Config::lmsPort() << " named \"" << Config::lmsName() << "\"" << endl;
 		cout << "  LCDd: " << Config::lcdHost() << ":" << Config::lcdPort() << endl;
 		cout << "  PlayerId (MAC): " << Config::playerId() << endl;
-		cout << "  Input device: " << Config::inputDeviceFile() << endl;
+		cout << "  Input device: " << endl;
+		for (string const i_file : Config::inputDeviceFiles())
+			cout << "    - " << i_file << endl;
 	}
 
 	while (1)


### PR DESCRIPTION
This capability leans a bit on #41, however it adds on the ability for a user to leverage multiple input device objects. This is relevant for those of us using rotary encoders, as the push button switch and left-right directions are normally placed in different files in /dev/input/. 

Multiple inputs are specified by passing `-i devpath1,devpath2` at runtime.